### PR TITLE
fix: remove unique constraint and set video field to array

### DIFF
--- a/backend/prisma/migrations/20251028184525_initial_db_schema/migration.sql
+++ b/backend/prisma/migrations/20251028184525_initial_db_schema/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Video" DROP CONSTRAINT "Video_season_id_fkey";
+
+-- DropIndex
+DROP INDEX "Video_season_id_key";

--- a/backend/prisma/migrations/20251028185652_/migration.sql
+++ b/backend/prisma/migrations/20251028185652_/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "Video" ADD CONSTRAINT "Video_season_id_fkey" FOREIGN KEY ("season_id") REFERENCES "Season"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20251028190126_/migration.sql
+++ b/backend/prisma/migrations/20251028190126_/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Season_title_id_key";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Video {
   title          Title?         @relation(fields: [movie_title_id], references: [id])
   movie_title_id Int?           @unique
   season         Season?        @relation(fields: [season_id], references: [id])
-  season_id      Int?           @unique
+  season_id      Int?           
   episode_number Int?
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
@@ -63,8 +63,8 @@ model Season {
   number    Int
   thumbnail String
   title     Title    @relation(fields: [title_id], references: [id])
-  title_id  Int      @unique
-  video     Video?
+  title_id  Int      
+  video     Video[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
### Summary

Allows multiple Videos per Season and multiple Seasons per Title. 
Update migration.

- resolves #100 